### PR TITLE
Make description haddock-friendlier

### DIFF
--- a/file-location.cabal
+++ b/file-location.cabal
@@ -13,7 +13,7 @@ Description:
     Common debugging\/error\/exception functions that give file location information
     .
     @
-    $(err "OH NO!")
+    $(err \"OH NO!\")
        
     main:Main main.hs:16:1 OH NO!
     @


### PR DESCRIPTION
The birdtrack markers in the package description do not properly show up
in the generated haddock documentation of the package. Hence replace
them by the @..@ construct.
