### PR TITLE
Could not find module `Control.Exception.Lifted'

### DIFF
--- a/file-location.cabal
+++ b/file-location.cabal
@@ -67,6 +67,7 @@ Library
   
   -- Packages needed in order to build this package.
   Build-depends:  base >= 4 && < 5
+                , lifted-base
                 , template-haskell
                 , transformers     >= 0.2 && < 0.4
                 , containers


### PR DESCRIPTION
The lifted-base dependency is missing from the cabal file.  Without this dependency, the build fails with the following error:

```
Control/Exception/FileLocation.hs:13:18:
    Could not find module `Control.Exception.Lifted'
    Perhaps you meant Control.Exception.Base (from base)
    Use -v to see a list of the files searched for.
```

Tested on [Haskell Platform 2012.4.0.0 32-bit RC2](http://ozonehouse.com/mark/platform/Haskell%20Platform%202012.4.0.0%2032bit%20rc2%20signed.pkg).

**NOTE**: I was unable to run the test suite because of an undocumented dependency on `shelltest`:

```
$ ./test/run.sh 
+ ghc --make test/main.hs
+ shelltest test/file-location.shelltest
./test/run.sh: line 2: shelltest: command not found
```

I apologize if my changes break the test suite.
