### PR TITLE
Add __LOC__, a template haskell function to embed a Loc value

### DIFF
--- a/Debug/FileLocation.hs
+++ b/Debug/FileLocation.hs
@@ -3,9 +3,11 @@
 -- Most would make sense in the Debug.Trace module
 -- There are Template Haskell versions that show you file locaiton information
 module Debug.FileLocation
-  (debug, debugM, debugMsg, dbg, dbgMsg, trc, ltrace, ltraceM, strace, traceId)
+  (debug, debugM, debugMsg, dbg, dbgMsg, trc, ltrace, ltraceM, strace, traceId, __LOC__)
   where
 
+import Control.Applicative ((<$>), (<*>), pure)
+import Language.Haskell.TH (recConE, litE, stringL, integerL)
 import Language.Haskell.TH.Syntax
 import Debug.Util
 import Debug.Trace (trace)
@@ -39,3 +41,20 @@ dbgM = do
   loc <- qLocation
   let prefix = "DEBUG: " ++ (locationToString loc) ++ " "
   [|(\_x -> ltraceM (prefix ++ show _x) _x)|]
+
+instance Lift Loc where
+    lift x = recConE 'Loc [ (,) <$> (pure 'loc_filename) <*> litE (stringL (loc_filename x))
+                          , (,) <$> (pure 'loc_package) <*> litE (stringL (loc_package x))
+                          , (,) <$> (pure 'loc_module) <*> litE (stringL (loc_module x))
+                          , (,) <$> (pure 'loc_start) <*> [|($(litE (integerL (fromIntegral (fst (loc_start x))))),
+                                                             $(litE (integerL (fromIntegral (snd (loc_start x)))))) :: (Int, Int)|]
+                          , (,) <$> (pure 'loc_end) <*> [|($(litE (integerL (fromIntegral (fst (loc_end x))))),
+                                                           $(litE (integerL (fromIntegral (snd (loc_end x)))))) :: (Int, Int)|] ]
+
+-- | Embed an expression of type Loc containing the location
+-- information for the place where it appears.  Could be used in
+-- custom Exception types and similar:
+--
+-- > throw $ MyException $__LOC__
+__LOC__ :: Q Exp
+__LOC__ = lift =<< location


### PR DESCRIPTION
I'm not sure where I came across **LOC**, but this seems like a good home for it.
