### PR TITLE
Use the Loc Lift instance now available in th-orphans

### DIFF
--- a/Debug/FileLocation.hs
+++ b/Debug/FileLocation.hs
@@ -8,6 +8,7 @@ module Debug.FileLocation
 
 import Control.Applicative ((<$>), (<*>), pure)
 import Language.Haskell.TH (recConE, litE, stringL, integerL)
+import Language.Haskell.TH.Instances
 import Language.Haskell.TH.Syntax
 import Debug.Util
 import Debug.Trace (trace)
@@ -41,15 +42,6 @@ dbgM = do
   loc <- qLocation
   let prefix = "DEBUG: " ++ (locationToString loc) ++ " "
   [|(\_x -> ltraceM (prefix ++ show _x) _x)|]
-
-instance Lift Loc where
-    lift x = recConE 'Loc [ (,) <$> (pure 'loc_filename) <*> litE (stringL (loc_filename x))
-                          , (,) <$> (pure 'loc_package) <*> litE (stringL (loc_package x))
-                          , (,) <$> (pure 'loc_module) <*> litE (stringL (loc_module x))
-                          , (,) <$> (pure 'loc_start) <*> [|($(litE (integerL (fromIntegral (fst (loc_start x))))),
-                                                             $(litE (integerL (fromIntegral (snd (loc_start x)))))) :: (Int, Int)|]
-                          , (,) <$> (pure 'loc_end) <*> [|($(litE (integerL (fromIntegral (fst (loc_end x))))),
-                                                           $(litE (integerL (fromIntegral (snd (loc_end x)))))) :: (Int, Int)|] ]
 
 -- | Embed an expression of type Loc containing the location
 -- information for the place where it appears.  Could be used in

--- a/file-location.cabal
+++ b/file-location.cabal
@@ -69,6 +69,7 @@ Library
   Build-depends:  base >= 4 && < 5
                 , lifted-base
                 , template-haskell
+                , th-orphans       >= 0.9
                 , transformers     >= 0.2 && < 0.5
                 , containers
 


### PR DESCRIPTION
The th-orphans package has Lift instances for most template haskell types, now including Loc.  Better to use that one than risk duplicate instance errors.